### PR TITLE
Remove duplicate join from get_foreign_keys

### DIFF
--- a/sqlalchemy_monetdb/dialect.py
+++ b/sqlalchemy_monetdb/dialect.py
@@ -204,7 +204,6 @@ class MonetDialect(default.DefaultDialect):
             JOIN sys.tables AS pktable ON (pktable.id = pkkey.table_id)
             JOIN sys.schemas AS fkschema ON (fkschema.id = fktable.schema_id)
             JOIN sys.schemas AS pkschema ON (pkschema.id = pktable.schema_id)
-            JOIN sys.tables AS pktable ON (pktable.id = pkkey.table_id)
             WHERE fkkey.rkey > -1
               AND fkkeycol.nr = pkkeycol.nr
               AND fktable.id = %(table_id)s


### PR DESCRIPTION
This duplicate pktable join messes up resolving table relations when doing reflection. As you can see, this join already happens on line 204.