### PR TITLE
fix ' unexpected parameter: bindparams' error

### DIFF
--- a/sqlalchemy_monetdb/dialect.py
+++ b/sqlalchemy_monetdb/dialect.py
@@ -85,9 +85,9 @@ class MonetDialect(default.DefaultDialect):
                     "where system = false "
                     "and type = 0 "
                     "and name=:name",
-                    bindparams=[
-                        sql.bindparam('name', util.text_type(table_name),
-                                      type_=sqltypes.Unicode)]
+                ).bindparams(
+                    sql.bindparam('name', util.text_type(table_name),
+                                  type_=sqltypes.Unicode)
                 )
             )
         else:


### PR DESCRIPTION
The `sql.text` does not expect a `bindparams` parameter (anymore). This would throw an exception on functions that rely on this function.