### PR TITLE
Add CI for testing suite

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,24 @@
+name: Linux
+
+on: [push]
+
+jobs:
+  linux-test:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        branch: [default]
+    container: monetdb/dev-builds:${{ matrix.branch }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Setup database
+        run: |
+          cd test 
+          ./initfarm.sh
+          ./initdb.sh
+      -
+        name: Run tests
+        run: python3 setup.py test

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,20 +5,37 @@ on: [push]
 jobs:
   linux-test:
     runs-on: ubuntu-20.04
+    continue-on-error: true
     strategy:
       matrix:
         branch: [default]
+        python-version: [3.6,3.7,3.8,3.9]
     container: monetdb/dev-builds:${{ matrix.branch }}
     steps:
       -
         name: Checkout
         uses: actions/checkout@v2
+
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
       -
         name: Setup database
         run: |
           cd test 
           ./initfarm.sh
           ./initdb.sh
+
       -
-        name: Run tests
-        run: python3 setup.py test
+        name: Install Tox
+        run: |
+          python -m pip install tox
+
+      -
+        name: Run Tox
+        run: |
+          python --version
+          python -m tox -e py${{ matrix.python-version}}

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 MonetDB dialect for SQLAlchemy
 ==============================
 
-This is the MonetDB dialect driver for SQLAlchemy. It has support for Python 2.7, 3.3+ and even PyPy. It supports
-SQLalchemy 1.0, 1.1 and 1.2.
+This is the MonetDB dialect driver for SQLAlchemy. It has support for Python from 3.3 onwards and even PyPy. It supports
+SQLalchemy 1.0, 1.1, 1.2, 1.3 & 1.4.
 
 
 Installation

--- a/test/README.rst
+++ b/test/README.rst
@@ -15,7 +15,7 @@ Create a test schema::
 
 Now you can run the test suite::
 
-    $ python setup.py test
+    $ tox
 
 
 If you want to test the MonetDBlite dialect backend you need to use pytest::

--- a/test/initfarm.sh
+++ b/test/initfarm.sh
@@ -1,8 +1,8 @@
-#!/usr/bin/env bash -ve
+#!/usr/bin/bash
 
 FARM="/tmp/monetdb"
 
-ps ax | grep monetdbd | grep -v grep | awk '{ print $1 }' | xargs kill -9
+# ps ax | grep monetdbd | grep -v grep | awk '{ print $1 }' | xargs kill -9
 
 monetdbd stop ${FARM} || true
 rm -rf ${FARM}

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,4 @@
 mock
 coverage
 pytest
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py{27,34,35,36,py}-sqlalchemy{10,11,12}
+envlist = py{3.6,3.7,3.8,3.9}-sqlalchemy{13,14}
 
 [testenv]
 deps = 
-    sqlalchemy10: sqlalchemy>=1.0,<1.1
-    sqlalchemy11: sqlalchemy>=1.1,<1.2
-    sqlalchemy12: sqlalchemy>=1.2b1,<1.3
+    py3.6: sqlalchemy>=1.3,<1.4
+    py3.7: sqlalchemy>=1.3,<1.4
+    py3.8: sqlalchemy>=1.4,<1.5
+    py3.9: sqlalchemy>=1.4,<1.5
     pytest
     mock
     coverage


### PR DESCRIPTION
This PR adds GitHub CI that runs the testing suite with `tox`. However, there is a bug plaguing python version `3.8` & `3.9` that I haven't encountered in the real wold, namely the `Could not parse rfc1738 URL from string 'None'` error. I wasn't able to pinpoint the bug exactly, but I think it has something to do with the way it reads the `setup.cfg`. When I swap it out for another legal connection string, it works fine.