### PR TITLE
Fix: failed to compile SQL for float/double columns

### DIFF
--- a/sqlalchemy_monetdb/monetdb_types.py
+++ b/sqlalchemy_monetdb/monetdb_types.py
@@ -16,7 +16,7 @@ class WRD(sqltypes.Integer):
 
 
 class DOUBLE_PRECISION(sqltypes.Float):
-    __visit_name__ = 'DOUBLE PRECISION'
+    __visit_name__ = 'DOUBLE_PRECISION'
 
 
 class TINYINT(sqltypes.Integer):


### PR DESCRIPTION
Visitor's name must contain only characters for Python symbols.